### PR TITLE
refactor: reduce test brittleness by referencing mock data and using flexible assertions

### DIFF
--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -4,15 +4,18 @@ import { navigate } from "gatsby";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Header from "../Header";
 
+// Mock data for the header
+const mockHeaderData = {
+  logoText: "Vanessa Sangiorgio",
+  navbar: [
+    { name: "Work", to: "/" },
+    { name: "About", to: "/about" },
+  ],
+};
+
 // Mock the useHeaderData hook
 vi.mock("hooks/useHeaderData", () => ({
-  useHeaderData: vi.fn(() => ({
-    logoText: "Vanessa Sangiorgio",
-    navbar: [
-      { name: "Work", to: "/" },
-      { name: "About", to: "/about" },
-    ],
-  })),
+  useHeaderData: vi.fn(() => mockHeaderData),
 }));
 
 describe("Header", () => {
@@ -23,20 +26,20 @@ describe("Header", () => {
   it("renders logo and navigation links with correct destinations", () => {
     render(<Header />);
 
-    expect(screen.getByText("Vanessa Sangiorgio")).toBeInTheDocument();
+    expect(screen.getByText(mockHeaderData.logoText)).toBeInTheDocument();
 
-    const workLink = screen.getByRole("link", { name: "Work" });
-    const aboutLink = screen.getByRole("link", { name: "About" });
-
-    expect(workLink).toHaveAttribute("href", "/");
-    expect(aboutLink).toHaveAttribute("href", "/about");
+    // Verify each nav link from mock data is rendered with correct destination
+    for (const navItem of mockHeaderData.navbar) {
+      const link = screen.getByRole("link", { name: navItem.name });
+      expect(link).toHaveAttribute("href", navItem.to);
+    }
   });
 
   it("clicking logo navigates to home page", async () => {
     const user = userEvent.setup();
     render(<Header />);
 
-    await user.click(screen.getByText("Vanessa Sangiorgio"));
+    await user.click(screen.getByText(mockHeaderData.logoText));
 
     expect(navigate).toHaveBeenCalledWith("/");
   });

--- a/src/components/__tests__/HomePageSections.test.tsx
+++ b/src/components/__tests__/HomePageSections.test.tsx
@@ -52,44 +52,46 @@ describe("HomePageSections", () => {
   it("renders all projects with their role, title, and description", () => {
     render(<HomePageSections />);
 
-    expect(screen.getByText("Near-U")).toBeInTheDocument();
-    expect(screen.getByText("Product Designer")).toBeInTheDocument();
-    expect(
-      screen.getByText("A dating app focused on meaningful connections."),
-    ).toBeInTheDocument();
-
-    expect(screen.getByText("GWR Rewards")).toBeInTheDocument();
-    expect(screen.getByText("UX Designer")).toBeInTheDocument();
-    expect(
-      screen.getByText("A rewards program for train passengers."),
-    ).toBeInTheDocument();
+    // Verify each project from mock data is rendered
+    for (const section of mockSections) {
+      expect(screen.getByText(section.projectTitle)).toBeInTheDocument();
+      expect(screen.getByText(section.projectRole)).toBeInTheDocument();
+      expect(
+        screen.getByText(section.projectDescription.projectDescription),
+      ).toBeInTheDocument();
+    }
   });
 
   it("navigates to case study when clicking on a project section", async () => {
     const user = userEvent.setup();
     render(<HomePageSections />);
 
-    const nearUTitle = screen.getByText("Near-U");
-    const section = nearUTitle.closest("section");
+    const firstProject = mockSections[0];
+    const projectTitle = screen.getByText(firstProject.projectTitle);
+    const section = projectTitle.closest("section");
     await user.click(section!);
 
-    expect(navigate).toHaveBeenCalledWith("/case-studies/near-u");
+    expect(navigate).toHaveBeenCalledWith(firstProject.projectPath);
   });
 
   it("navigates to case study when clicking Read More", async () => {
     const user = userEvent.setup();
     render(<HomePageSections />);
 
-    const readMoreLinks = screen.getAllByText("Read More");
-    await user.click(readMoreLinks[1]);
+    const secondProject = mockSections[1];
+    // Find "Read More" text elements and click the one for the second project
+    const readMoreElements = screen.getAllByText(/^Read More$/);
+    await user.click(readMoreElements[1]);
 
-    expect(navigate).toHaveBeenCalledWith("/case-studies/gwr-rewards");
+    expect(navigate).toHaveBeenCalledWith(secondProject.projectPath);
   });
 
   it("displays project images with correct alt text", () => {
     render(<HomePageSections />);
 
-    expect(screen.getByAltText("Near-U")).toBeInTheDocument();
-    expect(screen.getByAltText("GWR Rewards")).toBeInTheDocument();
+    // Verify each project image uses the section name as alt text
+    for (const section of mockSections) {
+      expect(screen.getByAltText(section.sectionName)).toBeInTheDocument();
+    }
   });
 });

--- a/src/components/__tests__/SEO.test.tsx
+++ b/src/components/__tests__/SEO.test.tsx
@@ -2,13 +2,16 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import SEO from "../SEO";
 
+// Mock data for site metadata
+const mockSiteMetadata = {
+  title: "Vanessa Sangiorgio",
+  description: "Product Designer Portfolio",
+  siteUrl: "https://vanessasangiorgio.com",
+};
+
 // Mock the useSiteMetadata hook
 vi.mock("hooks/useSiteMetaData", () => ({
-  useSiteMetadata: vi.fn(() => ({
-    title: "Vanessa Sangiorgio",
-    description: "Product Designer Portfolio",
-    siteUrl: "https://vanessasangiorgio.com",
-  })),
+  useSiteMetadata: vi.fn(() => mockSiteMetadata),
 }));
 
 describe("SEO", () => {
@@ -16,20 +19,21 @@ describe("SEO", () => {
     render(<SEO />);
 
     expect(document.querySelector("title")?.textContent).toBe(
-      "Vanessa Sangiorgio",
+      mockSiteMetadata.title,
     );
     expect(
       document
         .querySelector('meta[name="description"]')
         ?.getAttribute("content"),
-    ).toBe("Product Designer Portfolio");
+    ).toBe(mockSiteMetadata.description);
   });
 
   it("renders custom title appended to site name", () => {
-    render(<SEO title="Work Page" />);
+    const customTitle = "Work Page";
+    render(<SEO title={customTitle} />);
 
     expect(document.querySelector("title")?.textContent).toBe(
-      "Vanessa Sangiorgio - Work Page",
+      `${mockSiteMetadata.title} - ${customTitle}`,
     );
   });
 

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,4 @@
+// Auth-related constants shared between source and tests
+export const AUTH_COOKIE_NAME = "passwordSet";
+export const AUTH_COOKIE_VALUE = "true";
+export const AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days in seconds

--- a/src/pages/__tests__/password.test.tsx
+++ b/src/pages/__tests__/password.test.tsx
@@ -65,15 +65,14 @@ describe("PasswordPage", () => {
   it("renders the password form with essential elements", () => {
     render(<PasswordPage location={createMockLocation()} />);
 
-    expect(
-      screen.getByText("Please enter password to view this case study"),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    // Check for key structural elements, using partial matching for copy that may change
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
     expect(screen.getByRole("button")).toBeInTheDocument();
-    expect(screen.getByText("Request it here")).toHaveAttribute(
-      "href",
-      "mailto:vanessa.sangiorgio@yahoo.co.uk",
-    );
+    // Verify there's a contact link with mailto (email address may change)
+    expect(
+      screen.getByRole("link", { name: /request/i }),
+    ).toHaveAttribute("href", expect.stringContaining("mailto:"));
   });
 
   it("submit button is disabled until user enters text", async () => {
@@ -83,7 +82,7 @@ describe("PasswordPage", () => {
     const submitButton = screen.getByRole("button");
     expect(submitButton).toBeDisabled();
 
-    await user.type(screen.getByLabelText("Password"), "sometext");
+    await user.type(screen.getByLabelText(/password/i), "sometext");
     expect(submitButton).toBeEnabled();
   });
 
@@ -93,7 +92,7 @@ describe("PasswordPage", () => {
 
     render(<PasswordPage location={createMockLocation()} />);
 
-    await user.type(screen.getByLabelText("Password"), "wrongpassword");
+    await user.type(screen.getByLabelText(/password/i), "wrongpassword");
     await user.click(screen.getByRole("button"));
 
     expect(screen.getByText(/Incorrect password/i)).toBeInTheDocument();
@@ -107,7 +106,7 @@ describe("PasswordPage", () => {
 
     render(<PasswordPage location={createMockLocation()} />);
 
-    const passwordInput = screen.getByLabelText("Password");
+    const passwordInput = screen.getByLabelText(/password/i);
     await user.type(passwordInput, "wrongpassword");
     await user.click(screen.getByRole("button"));
 
@@ -126,7 +125,7 @@ describe("PasswordPage", () => {
 
     render(<PasswordPage location={createMockLocation()} />);
 
-    await user.type(screen.getByLabelText("Password"), "correctpassword");
+    await user.type(screen.getByLabelText(/password/i), "correctpassword");
     await user.click(screen.getByRole("button"));
 
     expect(setCookie).toHaveBeenCalled();
@@ -141,7 +140,7 @@ describe("PasswordPage", () => {
 
     render(<PasswordPage location={createMockLocation({ state: null })} />);
 
-    await user.type(screen.getByLabelText("Password"), "correctpassword");
+    await user.type(screen.getByLabelText(/password/i), "correctpassword");
     await user.click(screen.getByRole("button"));
 
     expect(navigate).toHaveBeenCalledWith("/");

--- a/src/utils/__tests__/isPasswordSet.test.ts
+++ b/src/utils/__tests__/isPasswordSet.test.ts
@@ -1,3 +1,4 @@
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_VALUE } from "constants/auth";
 import { clearAllCookies } from "test-utils/cookies";
 import { afterEach, describe, expect, it } from "vitest";
 import { isPasswordSet } from "../isPasswordSet";
@@ -11,19 +12,19 @@ describe("isPasswordSet", () => {
     expect(isPasswordSet()).toBe(false);
   });
 
-  it("returns true when passwordSet cookie exists", () => {
-    document.cookie = "passwordSet=true";
+  it("returns true when auth cookie exists", () => {
+    document.cookie = `${AUTH_COOKIE_NAME}=${AUTH_COOKIE_VALUE}`;
     expect(isPasswordSet()).toBe(true);
   });
 
-  it("returns true when passwordSet cookie exists among other cookies", () => {
+  it("returns true when auth cookie exists among other cookies", () => {
     document.cookie = "otherCookie=value";
-    document.cookie = "passwordSet=true";
+    document.cookie = `${AUTH_COOKIE_NAME}=${AUTH_COOKIE_VALUE}`;
     document.cookie = "anotherCookie=anotherValue";
     expect(isPasswordSet()).toBe(true);
   });
 
-  it("returns false when other cookies exist but not passwordSet", () => {
+  it("returns false when other cookies exist but not auth cookie", () => {
     document.cookie = "someCookie=someValue";
     document.cookie = "anotherCookie=anotherValue";
     expect(isPasswordSet()).toBe(false);

--- a/src/utils/__tests__/setCookie.test.ts
+++ b/src/utils/__tests__/setCookie.test.ts
@@ -1,3 +1,4 @@
+import { AUTH_COOKIE_NAME, AUTH_COOKIE_VALUE } from "constants/auth";
 import { clearAllCookies } from "test-utils/cookies";
 import { afterEach, describe, expect, it } from "vitest";
 import { setCookie } from "../setCookie";
@@ -7,9 +8,11 @@ describe("setCookie", () => {
     clearAllCookies();
   });
 
-  it("sets passwordSet cookie with default values", () => {
+  it("sets auth cookie with default values", () => {
     setCookie();
-    expect(document.cookie).toContain("passwordSet=true");
+    expect(document.cookie).toContain(
+      `${AUTH_COOKIE_NAME}=${AUTH_COOKIE_VALUE}`,
+    );
   });
 
   it("sets cookie with custom name and value", () => {
@@ -19,6 +22,8 @@ describe("setCookie", () => {
 
   it("returns the cookie string that was set", () => {
     const result = setCookie("testCookie", "testValue", 3600);
-    expect(result).toBe("testCookie=testValue; max-age=3600;");
+    // Verify the cookie string contains the expected parts
+    expect(result).toContain("testCookie=testValue");
+    expect(result).toContain("max-age=3600");
   });
 });

--- a/src/utils/isPasswordSet.ts
+++ b/src/utils/isPasswordSet.ts
@@ -1,3 +1,5 @@
+import { AUTH_COOKIE_NAME } from "constants/auth";
+
 export function isPasswordSet() {
   if (typeof document !== "undefined") {
     const cookies = Object.fromEntries(
@@ -6,7 +8,7 @@ export function isPasswordSet() {
         .map(v => v.split(/=(.*)/s).map(decodeURIComponent)),
     );
 
-    if ("passwordSet" in cookies) {
+    if (AUTH_COOKIE_NAME in cookies) {
       return true;
     }
   }

--- a/src/utils/setCookie.ts
+++ b/src/utils/setCookie.ts
@@ -1,7 +1,13 @@
+import {
+  AUTH_COOKIE_MAX_AGE,
+  AUTH_COOKIE_NAME,
+  AUTH_COOKIE_VALUE,
+} from "constants/auth";
+
 export function setCookie(
-  name = "passwordSet",
-  value = "true",
-  maxAge: number = 60 * 60 * 24 * 30,
+  name = AUTH_COOKIE_NAME,
+  value = AUTH_COOKIE_VALUE,
+  maxAge: number = AUTH_COOKIE_MAX_AGE,
 ) {
   if (typeof document !== "undefined") {
     const cookieValue = `${name}=${value}; max-age=${maxAge};`;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   resolve: {
     alias: {
       components: path.resolve(__dirname, "./src/components"),
+      constants: path.resolve(__dirname, "./src/constants"),
       hooks: path.resolve(__dirname, "./src/hooks"),
       utils: path.resolve(__dirname, "./src/utils"),
       assets: path.resolve(__dirname, "./src/assets"),


### PR DESCRIPTION
- Extract mock data to variables and reference them in assertions instead of duplicating strings
- Create shared auth constants (AUTH_COOKIE_NAME, AUTH_COOKIE_VALUE, AUTH_COOKIE_MAX_AGE)
- Use semantic queries and partial matching in password tests
- Use flexible assertions (.toContain) instead of exact string matching in cookie tests
- Add constants alias to vitest config

https://claude.ai/code/session_01HSh4ywq5RRi4G2BLd8k7FT